### PR TITLE
TK-12

### DIFF
--- a/project/functions/src/firebase-hooks/votes.ts
+++ b/project/functions/src/firebase-hooks/votes.ts
@@ -26,7 +26,7 @@ export default function (adminSDK: admin.app.App) {
 
      todaysVotes.docs.forEach( async doc => {
         doc.ref.update({
-          active: false
+          inactive: true
         })
       });
 
@@ -97,7 +97,7 @@ export default function (adminSDK: admin.app.App) {
 
 
       return document.ref.update({
-        active: true,
+        inactive: false,
         timestamp
       });
     } catch (error) {

--- a/project/functions/ui-src/app/pages/home/home.ts
+++ b/project/functions/ui-src/app/pages/home/home.ts
@@ -69,8 +69,8 @@ class HomeElement extends PageComponent {
         Router.navigate('/new-user');
       }
 
-      VoteService.findVotes({ voter: user.id, active: true });
-      RaceService.findRaces({ userId: this.user.id, valid: true });
+      VoteService.findVotes({ voter: user.id, invalid: false });
+      RaceService.findRaces({ userId: this.user.id, invalid: false });
 
       this.loading = false;
       this.requestUpdate();


### PR DESCRIPTION
- Fix queries to `/races` and `/votes` which were looking for a property called `active` which did not mach up with the schema which instead set a flag called `inactive`